### PR TITLE
bzip2 support

### DIFF
--- a/dmg/CMakeLists.txt
+++ b/dmg/CMakeLists.txt
@@ -1,5 +1,6 @@
 INCLUDE(FindOpenSSL)
 INCLUDE(FindZLIB)
+INCLUDE(FindBZip2)
 
 FIND_LIBRARY(CRYPTO_LIBRARIES crypto
       PATHS
@@ -10,9 +11,14 @@ FIND_LIBRARY(CRYPTO_LIBRARIES crypto
 IF(NOT ZLIB_FOUND)
 	message(FATAL_ERROR "zlib is required for dmg!")
 ENDIF(NOT ZLIB_FOUND)
+IF(NOT BZIP2_FOUND)
+	message(FATAL_ERROR "bzip2 is required for dmg!")
+ENDIF(NOT BZIP2_FOUND)
 
 include_directories(${ZLIB_INCLUDE_DIR})
 link_directories(${ZLIB_LIBRARIES})
+include_directories(${BZIP2_INCLUDE_DIR})
+link_directories(${BZIP2_LIBRARIES})
 
 link_directories(${PROJECT_BINARY_DIR}/common ${PROJECT_BINARY_DIR}/hfs)
 
@@ -27,7 +33,7 @@ IF(OPENSSL_FOUND)
 	ENDIF(WIN32)
 ENDIF(OPENSSL_FOUND)
 
-target_link_libraries(dmg common hfs z)
+target_link_libraries(dmg common hfs z bz2)
 
 add_executable(dmg-bin dmg.c)
 target_link_libraries (dmg-bin dmg)

--- a/hfs/catalog.c
+++ b/hfs/catalog.c
@@ -533,23 +533,23 @@ HFSPlusCatalogRecord* getRecordFromPath3(const char* path, Volume* volume, char 
         }
       }
     }
-	
-    if(record->recordType == kHFSPlusFileRecord) {	
-	if((word + strlen(word) + 1) >= pathLimit) {
-		free(origPath);
-      
-		if(retKey != NULL) {
-			memcpy(retKey, &key, sizeof(HFSPlusCatalogKey));
-		}
-      
-		return record;
-	} else {
-		free(origPath);
-		free(record);
-		return NULL;
-	}
+
+    if(record->recordType == kHFSPlusFileRecord) {
+      if((word + strlen(word) + 1) >= pathLimit) {
+        free(origPath);
+
+        if(retKey != NULL) {
+          memcpy(retKey, &key, sizeof(HFSPlusCatalogKey));
+        }
+
+        return record;
+      } else {
+        free(origPath);
+        free(record);
+        return NULL;
+      }
     }
-    
+
     if(record->recordType != kHFSPlusFolderRecord)
       hfs_panic("inconsistent catalog tree!");
     

--- a/hfs/hfs.c
+++ b/hfs/hfs.c
@@ -132,13 +132,13 @@ void cmd_chmod(Volume* volume, int argc, const char *argv[]) {
 }
 
 void cmd_attr(Volume* volume, int argc, const char *argv[]) {
-        int mode;
+	int mode;
 
-        if(argc > 2) {
-                attrFile(argv[1], argv[2], volume);
-        } else {
-                printf("Not enough arguments");
-        }
+	if(argc > 2) {
+		attrFile(argv[1], argv[2], volume);
+	} else {
+		printf("Not enough arguments");
+	}
 }
 
 void cmd_extractall(Volume* volume, int argc, const char *argv[]) {
@@ -281,8 +281,8 @@ int main(int argc, const char *argv[]) {
 			cmd_rm(volume, argc - 2, argv + 2);
 		} else if(strcmp(argv[2], "chmod") == 0) {
 			cmd_chmod(volume, argc - 2, argv + 2);
-                } else if(strcmp(argv[2], "attr") == 0) {
-                        cmd_attr(volume, argc - 2, argv + 2);
+		} else if(strcmp(argv[2], "attr") == 0) {
+			cmd_attr(volume, argc - 2, argv + 2);
 		} else if(strcmp(argv[2], "extract") == 0) {
 			cmd_extract(volume, argc - 2, argv + 2);
 		} else if(strcmp(argv[2], "extractall") == 0) {

--- a/hfs/hfslib.c
+++ b/hfs/hfslib.c
@@ -323,6 +323,11 @@ void addAllInFolder(HFSCatalogNodeID folderID, Volume* volume, const char* paren
 			
 			fullName[pathLen] = '/';
 			fullName[pathLen + 1] = '\0';
+			/* Copy permissions from the source folder */
+			struct stat st;
+			ASSERT (lstat(ent->d_name, &st) == 0, "lstat");
+			chmodFile(fullName, (int)st.st_mode, volume);
+			printf("Setting permissions to %06o for %s\n", st.st_mode, fullName);
 			ASSERT(chdir(ent->d_name) == 0, "chdir");
 			addAllInFolder(cnid, volume, fullName);
 			ASSERT(chdir(cwd) == 0, "chdir");
@@ -337,6 +342,11 @@ void addAllInFolder(HFSCatalogNodeID folderID, Volume* volume, const char* paren
 			writeToHFSFile(outFile, file, volume);
 			file->close(file);
 			free(outFile);
+			/* Copy permissions from the source file */
+			struct stat st;
+			ASSERT (lstat(ent->d_name, &st) == 0, "lstat");
+			chmodFile(fullName, (int)st.st_mode, volume);
+			printf("Setting permissions to %06o for %s\n", st.st_mode, fullName);
 			
 			if(strncmp(fullName, "/Applications/", sizeof("/Applications/") - 1) == 0) {
 				testBuffer[0] = '\0';
@@ -450,7 +460,7 @@ void addall_hfs(Volume* volume, const char* dirToMerge, const char* dest) {
 	
 	if(record != NULL) {
 		if(record->recordType == kHFSPlusFolderRecord)
-			addAllInFolder(((HFSPlusCatalogFolder*)record)->folderID, volume, initPath);  
+			addAllInFolder(((HFSPlusCatalogFolder*)record)->folderID, volume, initPath);
 		else {
 			printf("Not a folder\n");
 			exit(0);

--- a/includes/common.h
+++ b/includes/common.h
@@ -35,33 +35,33 @@
 extern char endianness;
 
 static inline void flipEndian(unsigned char* x, int length) {
-  int i;
-  unsigned char tmp;
+	int i;
+	unsigned char tmp;
 
-  if(endianness == IS_BIG_ENDIAN) {
-    return;
-  } else {
-    for(i = 0; i < (length / 2); i++) {
-      tmp = x[i];
-      x[i] = x[length - i - 1];
-      x[length - i - 1] = tmp;
-    }
-  }
+	if(endianness == IS_BIG_ENDIAN) {
+		return;
+	} else {
+		for(i = 0; i < (length / 2); i++) {
+			tmp = x[i];
+			x[i] = x[length - i - 1];
+			x[length - i - 1] = tmp;
+		}
+	}
 }
 
 static inline void flipEndianLE(unsigned char* x, int length) {
-  int i;
-  unsigned char tmp;
+	int i;
+	unsigned char tmp;
 
-  if(endianness == IS_LITTLE_ENDIAN) {
-    return;
-  } else {
-    for(i = 0; i < (length / 2); i++) {
-      tmp = x[i];
-      x[i] = x[length - i - 1];
-      x[length - i - 1] = tmp;
-    }
-  }
+	if(endianness == IS_LITTLE_ENDIAN) {
+		return;
+	} else {
+		for(i = 0; i < (length / 2); i++) {
+			tmp = x[i];
+			x[i] = x[length - i - 1];
+			x[length - i - 1] = tmp;
+		}
+	}
 }
 
 static inline void hexToBytes(const char* hex, uint8_t** buffer, size_t* bytes) {
@@ -93,10 +93,10 @@ typedef int (*writeFunc)(struct io_func_struct* io, off_t location, size_t size,
 typedef void (*closeFunc)(struct io_func_struct* io);
 
 typedef struct io_func_struct {
-  void* data;
-  readFunc read;
-  writeFunc write;
-  closeFunc close;
+	void* data;
+	readFunc read;
+	writeFunc write;
+	closeFunc close;
 } io_func;
 
 #endif

--- a/includes/dmg/dmg.h
+++ b/includes/dmg/dmg.h
@@ -220,8 +220,8 @@ typedef struct ResourceData {
 	size_t dataLength;
 	int id;
 	char* name;
-    size_t dataXmlOffset;
-    size_t dataXmlSize;
+	size_t dataXmlOffset;
+	size_t dataXmlSize;
 	struct ResourceData* next;
 } ResourceData;
 
@@ -236,9 +236,9 @@ typedef struct ResourceKey {
 } ResourceKey;
 
 typedef struct {
-    unsigned long state[5];
-    unsigned long count[2];
-    unsigned char buffer[64];
+	unsigned long state[5];
+	unsigned long count[2];
+	unsigned char buffer[64];
 } SHA1_CTX;
 
 typedef struct {
@@ -282,8 +282,8 @@ extern "C" {
 	void writeBase64(AbstractFile* file, unsigned char* data, size_t dataLength, int tabLength, int width);
 	char* convertBase64(unsigned char* data, size_t dataLength, int tabLength, int width);
 
-    uint32_t checksumBitness(uint32_t type);
-    
+	uint32_t checksumBitness(uint32_t type);
+
 	uint32_t CRC32Checksum(uint32_t* crc, const unsigned char *buf, size_t len);
 	uint32_t CRC32ZeroesChecksum(uint32_t* crc, size_t len);    
 	uint32_t MKBlockChecksum(uint32_t* ckSum, const unsigned char* data, size_t len);
@@ -291,8 +291,8 @@ extern "C" {
 	void BlockSHA1CRC(void* token, const unsigned char* data, size_t len);
 	void BlockCRC(void* token, const unsigned char* data, size_t len);
 	void CRCProxy(void* token, const unsigned char* data, size_t len);
-    void CRCZeroesProxy(void* token, size_t len);
-    
+	void CRCZeroesProxy(void* token, size_t len);
+
 	void SHA1Transform(unsigned long state[5], const unsigned char buffer[64]);
 	void SHA1Init(SHA1_CTX* context);
 	void SHA1Update(SHA1_CTX* context, const unsigned char* data, unsigned int len);
@@ -338,8 +338,8 @@ extern "C" {
 
 	void extractBLKX(AbstractFile* in, AbstractFile* out, BLKXTable* blkx);
 	BLKXTable* insertBLKX(AbstractFile* out, AbstractFile* in, uint32_t firstSectorNumber, uint32_t numSectors, uint32_t blocksDescriptor,
-				uint32_t checksumType, ChecksumFunc uncompressedChk, void* uncompressedChkToken, ChecksumFunc compressedChk,
-				void* compressedChkToken, Volume* volume);
+	            uint32_t checksumType, ChecksumFunc uncompressedChk, void* uncompressedChkToken, ChecksumFunc compressedChk,
+	            void* compressedChkToken, Volume* volume);
 
 
 	int extractDmg(AbstractFile* abstractIn, AbstractFile* abstractOut, int partNum);

--- a/includes/dmg/dmgfile.h
+++ b/includes/dmg/dmgfile.h
@@ -14,13 +14,13 @@ io_func* openDmgFilePartition(AbstractFile* dmg, int partition);
 
 typedef struct DMG {
 	UDIFResourceFile resourceFile;
-    char* resourceXML;
+	char* resourceXML;
 	AbstractFile* dmg;
 	ResourceKey* resources;
 	uint32_t numBLKX;
 	BLKXTable** blkx;
 	void* runData;
-    uint32_t runType;
+	uint32_t runType;
 	uint64_t runStart;
 	uint64_t runEnd;
 	uint64_t offset;

--- a/includes/dmg/filevault.h
+++ b/includes/dmg/filevault.h
@@ -23,73 +23,73 @@
 #define FILEVAULT_V2_SIGNATURE 0x656e637263647361ULL
 
 typedef struct FileVaultV1Header {
-	uint8_t		padding1[48];
-	uint32_t	kdfIterationCount;
-	uint32_t	kdfSaltLen;
-	uint8_t		kdfSalt[48];
-	uint8_t		unwrapIV[0x20];
-	uint32_t	wrappedAESKeyLen;
-	uint8_t		wrappedAESKey[296];
-	uint32_t	wrappedHMACSHA1KeyLen;
-	uint8_t		wrappedHMACSHA1Key[300];
-	uint32_t	integrityKeyLen;
-	uint8_t		integrityKey[48];
-	uint8_t		padding2[484];
+	uint8_t     padding1[48];
+	uint32_t    kdfIterationCount;
+	uint32_t    kdfSaltLen;
+	uint8_t     kdfSalt[48];
+	uint8_t     unwrapIV[0x20];
+	uint32_t    wrappedAESKeyLen;
+	uint8_t     wrappedAESKey[296];
+	uint32_t    wrappedHMACSHA1KeyLen;
+	uint8_t     wrappedHMACSHA1Key[300];
+	uint32_t    integrityKeyLen;
+	uint8_t     integrityKey[48];
+	uint8_t     padding2[484];
 } __attribute__((__packed__)) FileVaultV1Header;
 
 typedef struct FileVaultV2Header {
-	uint64_t	signature;
-	uint32_t	version;
-	uint32_t	encIVSize;
-	uint32_t	unk1;
-	uint32_t	unk2;
-	uint32_t	unk3;
-	uint32_t	unk4;
-	uint32_t	unk5;
-	UDIFID		uuid;
-	uint32_t	blockSize;
-	uint64_t	dataSize;
-	uint64_t	dataOffset;
-	uint8_t		padding[0x260];
-	uint32_t	kdfAlgorithm;
-	uint32_t	kdfPRNGAlgorithm;
-	uint32_t	kdfIterationCount;
-	uint32_t	kdfSaltLen;
-	uint8_t 	kdfSalt[0x20];
-	uint32_t	blobEncIVSize;
-	uint8_t		blobEncIV[0x20];
-	uint32_t	blobEncKeyBits;
-	uint32_t	blobEncAlgorithm;
-	uint32_t	blobEncPadding;
-	uint32_t	blobEncMode;
-	uint32_t	encryptedKeyblobSize;
-	uint8_t	encryptedKeyblob[0x30];
+	uint64_t    signature;
+	uint32_t    version;
+	uint32_t    encIVSize;
+	uint32_t    unk1;
+	uint32_t    unk2;
+	uint32_t    unk3;
+	uint32_t    unk4;
+	uint32_t    unk5;
+	UDIFID      uuid;
+	uint32_t    blockSize;
+	uint64_t    dataSize;
+	uint64_t    dataOffset;
+	uint8_t     padding[0x260];
+	uint32_t    kdfAlgorithm;
+	uint32_t    kdfPRNGAlgorithm;
+	uint32_t    kdfIterationCount;
+	uint32_t    kdfSaltLen;
+	uint8_t     kdfSalt[0x20];
+	uint32_t    blobEncIVSize;
+	uint8_t     blobEncIV[0x20];
+	uint32_t    blobEncKeyBits;
+	uint32_t    blobEncAlgorithm;
+	uint32_t    blobEncPadding;
+	uint32_t    blobEncMode;
+	uint32_t    encryptedKeyblobSize;
+	uint8_t     encryptedKeyblob[0x30];
 } __attribute__((__packed__)) FileVaultV2Header;
 
 typedef struct FileVaultInfo {
 	union {
 		FileVaultV1Header v1;
 		FileVaultV2Header v2;
-	} header;
+	}             header;
 
-	uint8_t		version;
-	uint64_t	dataOffset;
-	uint64_t	dataSize;
-	uint32_t	blockSize;
+	uint8_t       version;
+	uint64_t      dataOffset;
+	uint64_t      dataSize;
+	uint32_t      blockSize;
 
-	AbstractFile*	file;
+	AbstractFile* file;
 
-	HMAC_CTX	hmacCTX;
-	AES_KEY		aesKey;
-	AES_KEY		aesEncKey;
+	HMAC_CTX      hmacCTX;
+	AES_KEY       aesKey;
+	AES_KEY       aesEncKey;
 
-	off_t		offset;
+	off_t         offset;
 
-	uint32_t	curChunk;
-	unsigned char	chunk[FILEVAULT_CHUNK_SIZE];
+	uint32_t      curChunk;
+	unsigned char chunk[FILEVAULT_CHUNK_SIZE];
 
-	char		dirty;
-	char		headerDirty;
+	char          dirty;
+	char          headerDirty;
 } FileVaultInfo;
 #endif
 

--- a/includes/hfs/hfsplus.h
+++ b/includes/hfs/hfsplus.h
@@ -17,8 +17,8 @@
 #define READ_DATA(a, b, c) ((*((a)->dataRead))(b, c))
 
 struct BTKey {
-  uint16_t keyLength;
-  unsigned char data[0];
+	uint16_t keyLength;
+	unsigned char data[0];
 } __attribute__((__packed__));
 
 typedef struct BTKey BTKey;
@@ -31,95 +31,95 @@ typedef int (*compareFunc)(BTKey* left, BTKey* right);
 typedef uint32_t HFSCatalogNodeID;
 
 enum {
-    kHFSRootParentID            = 1,
-    kHFSRootFolderID            = 2,
-    kHFSExtentsFileID           = 3,
-    kHFSCatalogFileID           = 4,
-    kHFSBadBlockFileID          = 5,
-    kHFSAllocationFileID        = 6,
-    kHFSStartupFileID           = 7,
-    kHFSAttributesFileID        = 8,
-    kHFSRepairCatalogFileID     = 14,
-    kHFSBogusExtentFileID       = 15,
-    kHFSFirstUserCatalogNodeID  = 16
+	kHFSRootParentID            = 1,
+	kHFSRootFolderID            = 2,
+	kHFSExtentsFileID           = 3,
+	kHFSCatalogFileID           = 4,
+	kHFSBadBlockFileID          = 5,
+	kHFSAllocationFileID        = 6,
+	kHFSStartupFileID           = 7,
+	kHFSAttributesFileID        = 8,
+	kHFSRepairCatalogFileID     = 14,
+	kHFSBogusExtentFileID       = 15,
+	kHFSFirstUserCatalogNodeID  = 16
 };
 
 #define STR_SIZE(str) (sizeof(uint16_t) + (sizeof(uint16_t) * (str).length))
 
 struct HFSUniStr255 {
-    uint16_t  length;
-    uint16_t unicode[255];
+	uint16_t  length;
+	uint16_t unicode[255];
 } __attribute__((__packed__));
 typedef struct HFSUniStr255 HFSUniStr255;
 typedef const  HFSUniStr255 *ConstHFSUniStr255Param;
 
 struct HFSPlusExtentDescriptor {
-    uint32_t startBlock;
-    uint32_t blockCount;
+	uint32_t startBlock;
+	uint32_t blockCount;
 } __attribute__((__packed__));
 typedef struct HFSPlusExtentDescriptor HFSPlusExtentDescriptor;
 
 typedef HFSPlusExtentDescriptor HFSPlusExtentRecord[8];
 
 struct HFSPlusForkData {
-  uint64_t logicalSize;
-  uint32_t clumpSize;
-  uint32_t totalBlocks;
-  HFSPlusExtentRecord extents;
+	uint64_t logicalSize;
+	uint32_t clumpSize;
+	uint32_t totalBlocks;
+	HFSPlusExtentRecord extents;
 } __attribute__((__packed__));
 typedef struct HFSPlusForkData HFSPlusForkData;
  
 struct HFSPlusVolumeHeader {
-  uint16_t signature;
-  uint16_t version;
-  uint32_t attributes;
-  uint32_t lastMountedVersion;
-  uint32_t journalInfoBlock;
- 
-  uint32_t createDate;
-  uint32_t modifyDate;
-  uint32_t backupDate;
-  uint32_t checkedDate;
- 
-  uint32_t fileCount;
-  uint32_t folderCount;
- 
-  uint32_t blockSize;
-  uint32_t totalBlocks;
-  uint32_t freeBlocks;
- 
-  uint32_t nextAllocation;
-  uint32_t rsrcClumpSize;
-  uint32_t dataClumpSize;
-  HFSCatalogNodeID nextCatalogID;
- 
-  uint32_t writeCount;
-  uint64_t encodingsBitmap;
- 
-  uint32_t finderInfo[8];
- 
-  HFSPlusForkData allocationFile;
-  HFSPlusForkData extentsFile;
-  HFSPlusForkData catalogFile;
-  HFSPlusForkData attributesFile;
-  HFSPlusForkData startupFile;
+	uint16_t signature;
+	uint16_t version;
+	uint32_t attributes;
+	uint32_t lastMountedVersion;
+	uint32_t journalInfoBlock;
+
+	uint32_t createDate;
+	uint32_t modifyDate;
+	uint32_t backupDate;
+	uint32_t checkedDate;
+
+	uint32_t fileCount;
+	uint32_t folderCount;
+
+	uint32_t blockSize;
+	uint32_t totalBlocks;
+	uint32_t freeBlocks;
+
+	uint32_t nextAllocation;
+	uint32_t rsrcClumpSize;
+	uint32_t dataClumpSize;
+	HFSCatalogNodeID nextCatalogID;
+
+	uint32_t writeCount;
+	uint64_t encodingsBitmap;
+
+	uint32_t finderInfo[8];
+
+	HFSPlusForkData allocationFile;
+	HFSPlusForkData extentsFile;
+	HFSPlusForkData catalogFile;
+	HFSPlusForkData attributesFile;
+	HFSPlusForkData startupFile;
 } __attribute__((__packed__));
 typedef struct HFSPlusVolumeHeader HFSPlusVolumeHeader;
 
 enum {
-    kBTLeafNode       = -1,
-    kBTIndexNode      =  0,
-    kBTHeaderNode     =  1,
-    kBTMapNode        =  2
+	kBTLeafNode       = -1,
+	kBTIndexNode      =  0,
+	kBTHeaderNode     =  1,
+	kBTMapNode        =  2
 };
 
 struct BTNodeDescriptor {
-    uint32_t    fLink;
-    uint32_t    bLink;
-    int8_t     kind;
-    uint8_t     height;
-    uint16_t    numRecords;
-    uint16_t    reserved;
+	uint32_t    fLink;
+	uint32_t    bLink;
+	int8_t      kind;
+	uint8_t     height;
+	uint16_t    numRecords;
+	uint16_t    reserved;
 } __attribute__((__packed__));
 typedef struct BTNodeDescriptor BTNodeDescriptor;
 
@@ -127,137 +127,137 @@ typedef struct BTNodeDescriptor BTNodeDescriptor;
 #define kHFSBinaryCompare 0xBC
 
 struct BTHeaderRec {
-    uint16_t    treeDepth;
-    uint32_t    rootNode;
-    uint32_t    leafRecords;
-    uint32_t    firstLeafNode;
-    uint32_t    lastLeafNode;
-    uint16_t    nodeSize;
-    uint16_t    maxKeyLength;
-    uint32_t    totalNodes;
-    uint32_t    freeNodes;
-    uint16_t    reserved1;
-    uint32_t    clumpSize;      // misaligned
-    uint8_t     btreeType;
-    uint8_t     keyCompareType;
-    uint32_t    attributes;     // long aligned again
-    uint32_t    reserved3[16];
+	uint16_t    treeDepth;
+	uint32_t    rootNode;
+	uint32_t    leafRecords;
+	uint32_t    firstLeafNode;
+	uint32_t    lastLeafNode;
+	uint16_t    nodeSize;
+	uint16_t    maxKeyLength;
+	uint32_t    totalNodes;
+	uint32_t    freeNodes;
+	uint16_t    reserved1;
+	uint32_t    clumpSize;      // misaligned
+	uint8_t     btreeType;
+	uint8_t     keyCompareType;
+	uint32_t    attributes;     // long aligned again
+	uint32_t    reserved3[16];
 } __attribute__((__packed__));
 typedef struct BTHeaderRec BTHeaderRec;
 
 struct HFSPlusExtentKey {
-    uint16_t              keyLength;
-    uint8_t               forkType;
-    uint8_t               pad;
-    HFSCatalogNodeID    fileID;
-    uint32_t              startBlock;
+	uint16_t            keyLength;
+	uint8_t             forkType;
+	uint8_t             pad;
+	HFSCatalogNodeID    fileID;
+	uint32_t            startBlock;
 } __attribute__((__packed__));
 typedef struct HFSPlusExtentKey HFSPlusExtentKey;
 
 struct HFSPlusCatalogKey {
-    uint16_t              keyLength;
-    HFSCatalogNodeID    parentID;
-    HFSUniStr255        nodeName;
+	uint16_t            keyLength;
+	HFSCatalogNodeID    parentID;
+	HFSUniStr255        nodeName;
 } __attribute__((__packed__));
 typedef struct HFSPlusCatalogKey HFSPlusCatalogKey;
 
 #ifndef __MACTYPES__
 struct Point {
-  int16_t              v;
-  int16_t              h;
+	int16_t              v;
+	int16_t              h;
 } __attribute__((__packed__));
 typedef struct Point  Point;
 
 struct Rect {
-  int16_t              top;
-  int16_t              left;
-  int16_t              bottom;
-  int16_t              right;
+	int16_t              top;
+	int16_t              left;
+	int16_t              bottom;
+	int16_t              right;
 } __attribute__((__packed__));
 typedef struct Rect   Rect;
 
 /* OSType is a 32-bit value made by packing four 1-byte characters 
    together. */
 typedef uint32_t        FourCharCode;
-typedef FourCharCode  OSType;
+typedef FourCharCode    OSType;
 
 #endif
 
 /* Finder flags (finderFlags, fdFlags and frFlags) */
 enum {
-  kIsOnDesk       = 0x0001,     /* Files and folders (System 6) */
-  kColor          = 0x000E,     /* Files and folders */
-  kIsShared       = 0x0040,     /* Files only (Applications only) If */
-                                /* clear, the application needs */
-                                /* to write to its resource fork, */
-                                /* and therefore cannot be shared */
-                                /* on a server */
-  kHasNoINITs     = 0x0080,     /* Files only (Extensions/Control */
-                                /* Panels only) */
-                                /* This file contains no INIT resource */
-  kHasBeenInited  = 0x0100,     /* Files only.  Clear if the file */
-                                /* contains desktop database resources */
-                                /* ('BNDL', 'FREF', 'open', 'kind'...) */
-                                /* that have not been added yet.  Set */
-                                /* only by the Finder. */
-                                /* Reserved for folders */
-  kHasCustomIcon  = 0x0400,     /* Files and folders */
-  kIsStationery   = 0x0800,     /* Files only */
-  kNameLocked     = 0x1000,     /* Files and folders */
-  kHasBundle      = 0x2000,     /* Files only */
-  kIsInvisible    = 0x4000,     /* Files and folders */
-  kIsAlias        = 0x8000      /* Files only */
+	kIsOnDesk       = 0x0001,     /* Files and folders (System 6) */
+	kColor          = 0x000E,     /* Files and folders */
+	kIsShared       = 0x0040,     /* Files only (Applications only) If */
+	                              /* clear, the application needs */
+	                              /* to write to its resource fork, */
+	                              /* and therefore cannot be shared */
+	                              /* on a server */
+	kHasNoINITs     = 0x0080,     /* Files only (Extensions/Control */
+	                              /* Panels only) */
+	                              /* This file contains no INIT resource */
+	kHasBeenInited  = 0x0100,     /* Files only.  Clear if the file */
+	                              /* contains desktop database resources */
+	                              /* ('BNDL', 'FREF', 'open', 'kind'...) */
+	                              /* that have not been added yet.  Set */
+	                              /* only by the Finder. */
+	                              /* Reserved for folders */
+	kHasCustomIcon  = 0x0400,     /* Files and folders */
+	kIsStationery   = 0x0800,     /* Files only */
+	kNameLocked     = 0x1000,     /* Files and folders */
+	kHasBundle      = 0x2000,     /* Files only */
+	kIsInvisible    = 0x4000,     /* Files and folders */
+	kIsAlias        = 0x8000      /* Files only */
 };
 
 /* Extended flags (extendedFinderFlags, fdXFlags and frXFlags) */
 enum {
-  kExtendedFlagsAreInvalid    = 0x8000, /* The other extended flags */
-                                        /* should be ignored */
-  kExtendedFlagHasCustomBadge = 0x0100, /* The file or folder has a */
-                                        /* badge resource */
-  kExtendedFlagHasRoutingInfo = 0x0004  /* The file contains routing */
-                                        /* info resource */
+	kExtendedFlagsAreInvalid    = 0x8000, /* The other extended flags */
+	                                      /* should be ignored */
+	kExtendedFlagHasCustomBadge = 0x0100, /* The file or folder has a */
+	                                      /* badge resource */
+	kExtendedFlagHasRoutingInfo = 0x0004  /* The file contains routing */
+	                                      /* info resource */
 };
 
 enum {
-    kSymLinkFileType  = 0x736C6E6B, /* 'slnk' */
-    kSymLinkCreator   = 0x72686170  /* 'rhap' */
+	kSymLinkFileType  = 0x736C6E6B, /* 'slnk' */
+	kSymLinkCreator   = 0x72686170  /* 'rhap' */
 };
 
 struct FileInfo {
-  OSType    fileType;           /* The type of the file */
-  OSType    fileCreator;        /* The file's creator */
-  uint16_t    finderFlags;
-  Point     location;           /* File's location in the folder. */
-  uint16_t    reservedField;
+	OSType      fileType;           /* The type of the file */
+	OSType      fileCreator;        /* The file's creator */
+	uint16_t    finderFlags;
+	Point       location;           /* File's location in the folder. */
+	uint16_t    reservedField;
 } __attribute__((__packed__));
 typedef struct FileInfo   FileInfo;
 
 struct ExtendedFileInfo {
-  int16_t    reserved1[4];
-  uint16_t    extendedFinderFlags;
-  int16_t    reserved2;
-  int32_t    putAwayFolderID;
+	int16_t    reserved1[4];
+	uint16_t   extendedFinderFlags;
+	int16_t    reserved2;
+	int32_t    putAwayFolderID;
 } __attribute__((__packed__));
 typedef struct ExtendedFileInfo   ExtendedFileInfo;
 
 struct FolderInfo {
-  Rect      windowBounds;       /* The position and dimension of the */
-                                /* folder's window */
-  uint16_t    finderFlags;
-  Point     location;           /* Folder's location in the parent */
-                                /* folder. If set to {0, 0}, the Finder */
-                                /* will place the item automatically */
-  uint16_t    reservedField;
+	Rect        windowBounds;     /* The position and dimension of the */
+	                              /* folder's window */
+	uint16_t    finderFlags;
+	Point       location;         /* Folder's location in the parent */
+	                              /* folder. If set to {0, 0}, the Finder */
+	                              /* will place the item automatically */
+	uint16_t    reservedField;
 } __attribute__((__packed__));
 typedef struct FolderInfo   FolderInfo;
 
 struct ExtendedFolderInfo {
-  Point     scrollPosition;     /* Scroll position (for icon views) */
-  int32_t    reserved1;
-  uint16_t    extendedFinderFlags;
-  int16_t    reserved2;
-  int32_t    putAwayFolderID;
+	Point      scrollPosition;     /* Scroll position (for icon views) */
+	int32_t    reserved1;
+	uint16_t   extendedFinderFlags;
+	int16_t    reserved2;
+	int32_t    putAwayFolderID;
 } __attribute__((__packed__));
 typedef struct ExtendedFolderInfo   ExtendedFolderInfo;
 
@@ -291,24 +291,24 @@ typedef struct ExtendedFolderInfo   ExtendedFolderInfo;
 #define S_IFWHT  0160000    /* whiteout */
 
 struct HFSPlusBSDInfo {
-    uint32_t  ownerID;
-    uint32_t  groupID;
-    uint8_t   adminFlags;
-    uint8_t   ownerFlags;
-    uint16_t  fileMode;
-    union {
-        uint32_t  iNodeNum;
-        uint32_t  linkCount;
-        uint32_t  rawDevice;
-    } special;
+	uint32_t  ownerID;
+	uint32_t  groupID;
+	uint8_t   adminFlags;
+	uint8_t   ownerFlags;
+	uint16_t  fileMode;
+	union {
+		uint32_t  iNodeNum;
+		uint32_t  linkCount;
+		uint32_t  rawDevice;
+	} special;
 } __attribute__((__packed__));
 typedef struct HFSPlusBSDInfo HFSPlusBSDInfo;
 
 enum {
-    kHFSPlusFolderRecord        = 0x0001,
-    kHFSPlusFileRecord          = 0x0002,
-    kHFSPlusFolderThreadRecord  = 0x0003,
-    kHFSPlusFileThreadRecord    = 0x0004
+	kHFSPlusFolderRecord        = 0x0001,
+	kHFSPlusFileRecord          = 0x0002,
+	kHFSPlusFolderThreadRecord  = 0x0003,
+	kHFSPlusFileThreadRecord    = 0x0004
 };
 
 enum {
@@ -335,99 +335,99 @@ enum {
 };
 
 struct HFSPlusCatalogFolder {
-    int16_t              recordType;
-    uint16_t              flags;
-    uint32_t              valence;
-    HFSCatalogNodeID    folderID;
-    uint32_t              createDate;
-    uint32_t              contentModDate;
-    uint32_t              attributeModDate;
-    uint32_t              accessDate;
-    uint32_t              backupDate;
-    HFSPlusBSDInfo      permissions;
-    FolderInfo          userInfo;
-    ExtendedFolderInfo  finderInfo;
-    uint32_t              textEncoding;
-    uint32_t              folderCount;
+	int16_t             recordType;
+	uint16_t            flags;
+	uint32_t            valence;
+	HFSCatalogNodeID    folderID;
+	uint32_t            createDate;
+	uint32_t            contentModDate;
+	uint32_t            attributeModDate;
+	uint32_t            accessDate;
+	uint32_t            backupDate;
+	HFSPlusBSDInfo      permissions;
+	FolderInfo          userInfo;
+	ExtendedFolderInfo  finderInfo;
+	uint32_t            textEncoding;
+	uint32_t            folderCount;
 } __attribute__((__packed__));
 typedef struct HFSPlusCatalogFolder HFSPlusCatalogFolder;
 
 struct HFSPlusCatalogFile {
-    int16_t              recordType;
-    uint16_t              flags;
-    uint32_t              reserved1;
-    HFSCatalogNodeID    fileID;
-    uint32_t              createDate;
-    uint32_t              contentModDate;
-    uint32_t              attributeModDate;
-    uint32_t              accessDate;
-    uint32_t              backupDate;
-    HFSPlusBSDInfo      permissions;
-    FileInfo            userInfo;
-    ExtendedFileInfo    finderInfo;
-    uint32_t              textEncoding;
-    uint32_t              reserved2;
- 
-    HFSPlusForkData     dataFork;
-    HFSPlusForkData     resourceFork;
+	int16_t             recordType;
+	uint16_t            flags;
+	uint32_t            reserved1;
+	HFSCatalogNodeID    fileID;
+	uint32_t            createDate;
+	uint32_t            contentModDate;
+	uint32_t            attributeModDate;
+	uint32_t            accessDate;
+	uint32_t            backupDate;
+	HFSPlusBSDInfo      permissions;
+	FileInfo            userInfo;
+	ExtendedFileInfo    finderInfo;
+	uint32_t            textEncoding;
+	uint32_t            reserved2;
+
+	HFSPlusForkData     dataFork;
+	HFSPlusForkData     resourceFork;
 } __attribute__((__packed__));
 typedef struct HFSPlusCatalogFile HFSPlusCatalogFile;
 
 struct HFSPlusCatalogThread {
-    int16_t              recordType;
-    int16_t              reserved;
-    HFSCatalogNodeID    parentID;
-    HFSUniStr255        nodeName;
+	int16_t             recordType;
+	int16_t             reserved;
+	HFSCatalogNodeID    parentID;
+	HFSUniStr255        nodeName;
 } __attribute__((__packed__));
 typedef struct HFSPlusCatalogThread HFSPlusCatalogThread;
 
 struct HFSPlusCatalogRecord {
-  int16_t recordType;
-  unsigned char data[0];
+	int16_t recordType;
+	unsigned char data[0];
 } __attribute__((__packed__));
 typedef struct HFSPlusCatalogRecord HFSPlusCatalogRecord;
 
 struct CatalogRecordList {
-  HFSUniStr255 name;
-  HFSPlusCatalogRecord* record;
-  struct CatalogRecordList* next;
+	HFSUniStr255 name;
+	HFSPlusCatalogRecord* record;
+	struct CatalogRecordList* next;
 };
 typedef struct CatalogRecordList CatalogRecordList;
 
 struct Extent {
-  uint32_t startBlock;
-  uint32_t blockCount;
-  struct Extent* next;
+	uint32_t startBlock;
+	uint32_t blockCount;
+	struct Extent* next;
 };
 
 typedef struct Extent Extent;
 
 typedef struct {
-  io_func* io;
-  BTHeaderRec *headerRec;
-  compareFunc compare;
-  dataReadFunc keyRead;
-  keyWriteFunc keyWrite;
-  keyPrintFunc keyPrint;
-  dataReadFunc dataRead;
+	io_func* io;
+	BTHeaderRec *headerRec;
+	compareFunc compare;
+	dataReadFunc keyRead;
+	keyWriteFunc keyWrite;
+	keyPrintFunc keyPrint;
+	dataReadFunc dataRead;
 } BTree;
 
 typedef struct {
-  io_func* image;
-  HFSPlusVolumeHeader* volumeHeader;
+	io_func* image;
+	HFSPlusVolumeHeader* volumeHeader;
 
-  BTree* extentsTree;
-  BTree* catalogTree;
-  io_func* allocationFile;
+	BTree* extentsTree;
+	BTree* catalogTree;
+	io_func* allocationFile;
 } Volume;
 
 
 typedef struct {
-  HFSCatalogNodeID id;
-  HFSPlusCatalogRecord* catalogRecord;
-  Volume* volume;
-  HFSPlusForkData* forkData;
-  Extent* extents;
+	HFSCatalogNodeID id;
+	HFSPlusCatalogRecord* catalogRecord;
+	Volume* volume;
+	HFSPlusForkData* forkData;
+	Extent* extents;
 } RawFile;
 
 #ifdef __cplusplus

--- a/includes/hfs/hfsplus.h
+++ b/includes/hfs/hfsplus.h
@@ -476,6 +476,7 @@ extern "C" {
 	int chmodFile(const char* pathName, int mode, Volume* volume);
 	int chownFile(const char* pathName, uint32_t owner, uint32_t group, Volume* volume);
 	int makeSymlink(const char* pathName, const char* target, Volume* volume);
+	int attrFile(const char* pathName, const char* flags, Volume* volume);
 
 	HFSPlusCatalogRecord* getRecordByCNID(HFSCatalogNodeID CNID, Volume* volume);
 	HFSPlusCatalogRecord* getLinkTarget(HFSPlusCatalogRecord* record, HFSCatalogNodeID parentID, HFSPlusCatalogKey *key, Volume* volume);


### PR DESCRIPTION
Either you're using this bzip2 branch internally, in which case maybe you should merge it to master so you don't lose your other patches about install path, or you're not, in which case your DMGs could be better compressed if you merge this to master, and you'll be able to deal with a wider variety of DMGs to boot.

From what I remember about the build process, the OSX packaging flow would always convert the DMG to UDBZ, which uses bzip2 compression.  The repackaging scripts (or anything that interacts with OSX-built artifacts) thus need to support bzip2.

I would guess that developers are installing from git master on their machines, but that your images are shipping a thing built from the bzip2 branch.  This means that developers on Linux machines may not be able to extract shipped, repackaged DMGs.

I suggest merging the branches, and then updating your repackaging Dockerfile to use the merged commit (or simply the master branch) for consistency.

Holler if you have any questions. :)

<3,
Drew
